### PR TITLE
Fix array results

### DIFF
--- a/client_cimxml.go
+++ b/client_cimxml.go
@@ -453,8 +453,8 @@ func (c *ClientCIMXML) EnumerateInstances(namespaceName, className string, deepI
 	}
 
 	results := make([]CIMInstanceWithName, len(resp.Message.SimpleRsp.IMethodResponse.ReturnValue.ValueNamedInstances))
-	for idx, instance := range resp.Message.SimpleRsp.IMethodResponse.ReturnValue.ValueNamedInstances {
-		results[idx] = &instance
+	for idx, _ := range resp.Message.SimpleRsp.IMethodResponse.ReturnValue.ValueNamedInstances {
+		results[idx] = &resp.Message.SimpleRsp.IMethodResponse.ReturnValue.ValueNamedInstances[idx]
 	}
 	return results, nil
 }
@@ -906,8 +906,8 @@ func (c *ClientCIMXML) AssociatorInstances(namespaceName string, instanceName CI
 	}
 
 	results := make([]CIMInstance, len(resp.Message.SimpleRsp.IMethodResponse.ReturnValue.Instances))
-	for idx, instance := range resp.Message.SimpleRsp.IMethodResponse.ReturnValue.Instances {
-		results[idx] = &instance
+	for idx, _ := range resp.Message.SimpleRsp.IMethodResponse.ReturnValue.Instances {
+		results[idx] = &resp.Message.SimpleRsp.IMethodResponse.ReturnValue.Instances[idx]
 	}
 	return results, nil
 }
@@ -1260,8 +1260,8 @@ func (c *ClientCIMXML) ReferenceInstances(namespaceName string, instanceName CIM
 	}
 
 	results := make([]CIMInstance, len(resp.Message.SimpleRsp.IMethodResponse.ReturnValue.Instances))
-	for idx, instance := range resp.Message.SimpleRsp.IMethodResponse.ReturnValue.Instances {
-		results[idx] = &instance
+	for idx, _ := range resp.Message.SimpleRsp.IMethodResponse.ReturnValue.Instances {
+		results[idx] = &resp.Message.SimpleRsp.IMethodResponse.ReturnValue.Instances[idx]
 	}
 	return results, nil
 }


### PR DESCRIPTION
When experimenting with EnumerateInstances when the result set has
more than 1 result,  all the results are identical.  After tracking
this down it appears to be an issue with returning the pointer for
`instance` in each of the for loops.  In these cases the address is
the same.  Returning the pointer for each of the actual addresses
in the array seems to correct the problem.

Notes: 
* This is my first exposure to golang, so this could be totally
wrong, but it's working for me and I only tested EnumerateInstances.
* The other corrections were based on the information determined from
finding this one.

Signed-off-by: Tony Asleson <tasleson@redhat.com>